### PR TITLE
Introduce keepAlive parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.carbon.esb.connector</groupId>
     <artifactId>org.wso2.carbon.connector.snowflake</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Connector For snowflake</name>
     <url>http://wso2.org</url>
@@ -36,7 +36,7 @@
         <automation.framework.version>4.4.3</automation.framework.version>
         <emma.version>2.1.5320</emma.version>
         <synapse.version>2.1.7-wso2v227</synapse.version>
-        <carbon.mediation.version>4.7.99.10</carbon.mediation.version>
+        <carbon.mediation.version>4.7.183</carbon.mediation.version>
         <org.testng.version>6.1.1</org.testng.version>
         <jets3t.version>0.9.4</jets3t.version>
         <bouncycastle.version>1.55</bouncycastle.version>

--- a/src/main/java/org/wso2/carbon/connector/connection/SnowflakeConnection.java
+++ b/src/main/java/org/wso2/carbon/connector/connection/SnowflakeConnection.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.connector.utils.Constants;
 
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Properties;
 
 /**
  * The Snowflake connection.
@@ -41,11 +42,15 @@ public class SnowflakeConnection implements Connection {
         String jdbcUrl = connectionConfiguration.getAccountIdentifier();
         String user = connectionConfiguration.getUser();
         String password = connectionConfiguration.getPassword();
+        String keepAlive = connectionConfiguration.getKeepAlive();
         String driver = Constants.SNOWFLAKE_DRIVER;
-
+        Properties properties = new Properties();
+        properties.put("user", user);
+        properties.put("password", password);
+        properties.put(Constants.CLIENT_SESSION_KEEP_ALIVE, Boolean.valueOf(keepAlive));
         try {
             Class.forName(driver);
-            this.connection = DriverManager.getConnection(jdbcUrl, user, password);
+            this.connection = DriverManager.getConnection(jdbcUrl, properties);
         } catch (ClassNotFoundException e) {
             throw new InvalidConfigurationException(
                     String.format("Error occurred while loading the Driver: %s", driver), e);

--- a/src/main/java/org/wso2/carbon/connector/operations/SnowflakeConfig.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SnowflakeConfig.java
@@ -60,7 +60,12 @@ public class SnowflakeConfig extends AbstractConnector implements ManagedLifecyc
                 }
 
                 SnowflakeConnection snowflakeConnection = new SnowflakeConnection(configuration);
-                handler.createConnection(Constants.CONNECTOR_NAME, connectionName, snowflakeConnection);
+                try {
+                    handler.createConnection(Constants.CONNECTOR_NAME, connectionName, snowflakeConnection, messageContext);
+                } catch (NoSuchMethodError e) {
+                    //Running in a version of Mediation that does not support local entry undeploy callback
+                    handler.createConnection(Constants.CONNECTOR_NAME, connectionName, snowflakeConnection);
+                }
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug(String.format("Connection exists for %s connector with connection name: %s.", connectorName,
@@ -111,11 +116,13 @@ public class SnowflakeConfig extends AbstractConnector implements ManagedLifecyc
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext, Constants.ACCOUNT_IDENTIFIER);
         String user = (String) ConnectorUtils.lookupTemplateParamater(messageContext, Constants.USER);
         String password = (String) ConnectorUtils.lookupTemplateParamater(messageContext, Constants.PASSWORD);
+        String keepAlive = (String) ConnectorUtils.lookupTemplateParamater(messageContext, Constants.KEEP_ALIVE);
 
         ConnectionConfiguration connectionConfiguration = new ConnectionConfiguration();
         connectionConfiguration.setAccountIdentifier(accountIdentifier);
         connectionConfiguration.setUser(user);
         connectionConfiguration.setPassword(password);
+        connectionConfiguration.setKeepAlive(keepAlive);
         return connectionConfiguration;
     }
 

--- a/src/main/java/org/wso2/carbon/connector/pojo/ConnectionConfiguration.java
+++ b/src/main/java/org/wso2/carbon/connector/pojo/ConnectionConfiguration.java
@@ -33,6 +33,8 @@ public class ConnectionConfiguration {
     private String user;
     private String password;
 
+    private String keepAlive = "false";
+
     /**
      * Get the connection name for the snowflake connection.
      *
@@ -115,5 +117,13 @@ public class ConnectionConfiguration {
             throw new InvalidConfigurationException("Mandatory parameter 'password' is not set.");
         }
         this.password = password;
+    }
+
+    public void setKeepAlive(String keepAlive) {
+        this.keepAlive = keepAlive;
+    }
+
+    public String getKeepAlive() {
+        return keepAlive;
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/utils/Constants.java
+++ b/src/main/java/org/wso2/carbon/connector/utils/Constants.java
@@ -37,4 +37,7 @@ public class Constants {
     public static final String PROPERTY_ERROR_MESSAGE = "ERROR_MESSAGE";
     public static final String STATUS_CODE = "HTTP_SC";
     public static final Object HTTP_STATUS_500 = "500";
+    public static final String CLIENT_SESSION_KEEP_ALIVE = "CLIENT_SESSION_KEEP_ALIVE";
+    public static final String KEEP_ALIVE = "keepAlive";
+
 }

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -21,11 +21,13 @@
     <parameter name="accountIdentifier"/>
     <parameter name="user"/>
     <parameter name="password"/>
+    <parameter name="keepAlive"/>
     <sequence>
         <property name="name" expression="$func:name"/>
         <property name="accountIdentifier" expression="$func:accountIdentifier"/>
         <property name="user" expression="$func:user"/>
         <property name="password" expression="$func:password"/>
+        <property name="keepAlive" expression="$func:keepAlive"/>
         <class name="org.wso2.carbon.connector.operations.SnowflakeConfig"/>
     </sequence>
 </template>

--- a/src/main/resources/uischema/connection.json
+++ b/src/main/resources/uischema/connection.json
@@ -58,6 +58,17 @@
                     "required": "true",
                     "helpTip": "Password you use to login to Snowflake account."
                   }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "keepAlive",
+                    "displayName": "Keep Alive",
+                    "inputType": "string",
+                    "defaultValue": "false",
+                    "required": "false",
+                    "helpTip": "Connection keep alive"
+                  }
                 }
               ]
             }


### PR DESCRIPTION
## Purpose
 Introducing `keepAlive` parameter to configure snowflake session parameter "CLIENT_SESSION_KEEP_ALIVE" [1].

Fixes https://github.com/wso2/micro-integrator/issues/3483


[1] - https://docs.snowflake.com/en/sql-reference/parameters#client-session-keep-alive

